### PR TITLE
Cached resource fix - Accept 304 status code

### DIFF
--- a/src/display/network_utils.js
+++ b/src/display/network_utils.js
@@ -92,7 +92,7 @@ function createResponseStatusError(status, url) {
 }
 
 function validateResponseStatus(status) {
-  return status === 200 || status === 206;
+  return [200,206,304].includes(status);
 }
 
 export {


### PR DESCRIPTION
Adding ability to accept 304 as succefull call, fixing bug which makes securceview stuck in loading screen
@phuocng 

304 is returned when PDFFetchStreamRangeReader is called and pdf resource is same as the cached one.
But when called on secureview (with protected pdf) the pdf-react-viewer is stuck on loading screen forever. 
Never showing the password input dialog.